### PR TITLE
fix(manifest): allow overriding start layer using query parameter

### DIFF
--- a/pychunkedgraph/app/meshing/common.py
+++ b/pychunkedgraph/app/meshing/common.py
@@ -75,6 +75,7 @@ def handle_get_manifest(table_id, node_id):
     return_seg_ids = return_seg_ids in ["True", "true", "1", True]
     prepend_seg_ids = prepend_seg_ids in ["True", "true", "1", True]
     start_layer = cg.meta.custom_data.get("mesh", {}).get("max_layer", 2)
+    start_layer = int(request.args.get("start_layer", start_layer))
     if "start_layer" in data:
         start_layer = int(data["start_layer"])
 


### PR DESCRIPTION
since the existing use of the body is not in the http spec

left the body override in since it is used by cloud-volume and possibly more